### PR TITLE
Add role work files policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,12 @@ This file defines how Codex orchestrates roles within this repository.
 - Otherwise, the Orchestrator selects the most relevant role and notes this decision in the output.
 - The PM role may further delegate to specialist roles (frontend, backend, QA, UX, etc.).
 
+## Role Files and Insights
+- Each role maintains a file under `roles/<role>.work.md` to capture insights and lessons learned during execution.
+- Agents may only edit their own `<role>.work.md` file. Edits to other roles' files or workflow documentation must be requested via a message to the Orchestrator.
+- Role switching into the Orchestrator is disallowed. Only tasks that explicitly request the Orchestrator can start it.
+- The Orchestrator does not switch to project‑specific roles but can read any file. Its modifications are limited to workflow files and documentation.
+
 ## Communication Between Agents
 - Role assignments and task outlines are committed to `plans/YYYY-MM-DD_<role>.agent.md`.
 - Agents exchange progress updates or questions in `messages/YYYY-MM-DD_<from>_to_<to>.md`.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This repository defines a multi-agent workflow orchestrated by Codex. The Orches
 - Role switches are logged under `plans/YYYY-MM-DD_<role>.agent.md`.
 - See `AGENTS.md` for detailed rules.
 
+Each role keeps its own `roles/<role>.work.md` file updated with insights during execution. Only the Orchestrator may edit other roles’ files or workflow documents, and roles must request such changes via a message file.
+
 ## Agent Communication
 Task assignments are committed to the `plans/` directory. Agents exchange progress or questions in `messages/YYYY-MM-DD_<from>_to_<to>.md`. These files provide a persistent record so the Orchestrator can seamlessly switch roles with minimal user involvement.
 

--- a/roles/orchestrator.work.md
+++ b/roles/orchestrator.work.md
@@ -1,0 +1,3 @@
+# Orchestrator Work Log
+
+Notes for orchestrator-specific workflow updates and governance decisions.

--- a/roles/pm.work.md
+++ b/roles/pm.work.md
@@ -1,0 +1,3 @@
+# PM Work Log
+
+Use this file to track project-management insights and decisions.


### PR DESCRIPTION
## Summary
- clarify that each role keeps a `roles/<role>.work.md` log
- disallow role switching into orchestrator and restrict orchestrator to workflow docs
- document new policy in README
- provide example `pm.work.md` and `orchestrator.work.md`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68836ee3d8808320ab806ee19881e9d3