### PR TITLE
Move workflow README to new file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Coverage
         run: echo "Check coverage >= 90% lines and 80% branches"
       - name: Doc Parity
-        run: echo "Ensure README and AGENTS are updated"
+        run: echo "Ensure WORKFLOW and AGENTS are updated"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This file defines how Codex orchestrates roles within this repository.
 1. Examine each task and determine which role should handle it.
 2. Log each role switch under `plans/YYYY-MM-DD_<role>.agent.md`.
 3. Remove finished plan files and summarize the outcome in `docs/FEATURES.md`.
-4. Enforce doc parity: changes to roles, CI, or workflow must update both `README.md` and this file.
+4. Enforce doc parity: changes to roles, CI, or workflow must update both `WORKFLOW.md` and this file.
 5. Maintain CI configuration in `.github/workflows/ci.yml`.
 
 ## Role Assumption

--- a/README.md
+++ b/README.md
@@ -1,28 +1,12 @@
-# Codex Project Workflow
+# Codex Project Template
 
-This repository defines a multi-agent workflow orchestrated by Codex. The Orchestrator Agent dynamically assumes roles (Project Manager, Frontend, Backend, QA, etc.) to fulfill tasks.
+This repository serves as a starting point for new multi-agent projects. It contains a working example of the Codex workflow along with governance documentation.
 
-## Role Switching
-- The Orchestrator reviews each task and decides which role best fits.
-- Role switches are logged under `plans/YYYY-MM-DD_<role>.agent.md`.
-- See `AGENTS.md` for detailed rules.
+## Using this template
 
-Each role keeps its own `roles/<role>.work.md` file updated with insights during execution. Only the Orchestrator may edit other roles’ files or workflow documents, and roles must request such changes via a message file.
+1. **Create your new project repository.** You can either use GitHub's "Use this template" feature or clone this repo and push to a new remote.
+2. **Copy the contents of this template into your project.** Retain `WORKFLOW.md`, `AGENTS.md`, and the `docs/` directory so your project follows the same governance.
+3. **Replace project-specific sections.** Update `README.md` in your project to describe your own code and goals while keeping `WORKFLOW.md` for the shared process.
+4. **Customize roles and CI as needed.** Add or modify role files under `roles/` and update CI steps once your tooling is defined.
 
-## Agent Communication
-Task assignments are committed to the `plans/` directory. Agents exchange progress or questions in `messages/YYYY-MM-DD_<from>_to_<to>.md`. These files provide a persistent record so the Orchestrator can seamlessly switch roles with minimal user involvement.
-
-## Documentation and Governance
-- Workflow policies are recorded in `/docs/` as RFCs, ADRs, QA, and Security guidelines.
-- Any change to roles, CI, or docs must update both this README and `AGENTS.md` (dual-doc enforcement).
-- Completed work is summarized in `/docs/FEATURES.md` after the related plan files are removed.
-
-## Continuous Integration
-- CI uses GitHub Actions (`.github/workflows/ci.yml`).
-- Specific lint, test, and coverage steps are defined by project requirements gathered by the PM role.
-
-## Getting Started
-1. Review `AGENTS.md` to understand how roles are assumed.
-2. Consult `/roles/pm.hire.md` for the PM role’s onboarding instructions.
-3. Use the `/docs/` directory to track governance and security information.
-4. Review `/docs/FEATURES.md` for a history of completed work.
+Refer to `WORKFLOW.md` for details on how agents communicate and how tasks are orchestrated.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,0 +1,28 @@
+# Codex Project Workflow
+
+This repository defines a multi-agent workflow orchestrated by Codex. The Orchestrator Agent dynamically assumes roles (Project Manager, Frontend, Backend, QA, etc.) to fulfill tasks.
+
+## Role Switching
+- The Orchestrator reviews each task and decides which role best fits.
+- Role switches are logged under `plans/YYYY-MM-DD_<role>.agent.md`.
+- See `AGENTS.md` for detailed rules.
+
+Each role keeps its own `roles/<role>.work.md` file updated with insights during execution. Only the Orchestrator may edit other roles’ files or workflow documents, and roles must request such changes via a message file.
+
+## Agent Communication
+Task assignments are committed to the `plans/` directory. Agents exchange progress or questions in `messages/YYYY-MM-DD_<from>_to_<to>.md`. These files provide a persistent record so the Orchestrator can seamlessly switch roles with minimal user involvement.
+
+## Documentation and Governance
+- Workflow policies are recorded in `/docs/` as RFCs, ADRs, QA, and Security guidelines.
+- Any change to roles, CI, or docs must update both `WORKFLOW.md` and `AGENTS.md` (dual-doc enforcement).
+- Completed work is summarized in `/docs/FEATURES.md` after the related plan files are removed.
+
+## Continuous Integration
+- CI uses GitHub Actions (`.github/workflows/ci.yml`).
+- Specific lint, test, and coverage steps are defined by project requirements gathered by the PM role.
+
+## Getting Started
+1. Review `AGENTS.md` to understand how roles are assumed.
+2. Consult `/roles/pm.hire.md` for the PM role’s onboarding instructions.
+3. Use the `/docs/` directory to track governance and security information.
+4. Review `/docs/FEATURES.md` for a history of completed work.

--- a/docs/ADRs/adr-20250725-0001-accept-workflow-policy.md
+++ b/docs/ADRs/adr-20250725-0001-accept-workflow-policy.md
@@ -7,5 +7,5 @@ The project requires a defined governance structure for multi-agent coordination
 Adopt the policies described in `RFC-0001 Initialize Workflow` and implement the dual-doc and CI rules.
 
 ## Consequences
-- Contributors must update both `README.md` and `AGENTS.md` when modifying governance or CI.
+- Contributors must update both `WORKFLOW.md` and `AGENTS.md` when modifying governance or CI.
 - CI will enforce lint, test, coverage, and doc parity once project tooling is specified.

--- a/docs/RFCs/rfc-0001-initialize-workflow.md
+++ b/docs/RFCs/rfc-0001-initialize-workflow.md
@@ -7,7 +7,7 @@ Establish the initial multi-agent workflow, governance files, and CI structure.
 Provide a consistent process for Codex to manage role assumptions, documentation, and continuous integration.
 
 ## Guide-level Explanation
-- Create `README.md` and `AGENTS.md` to document workflow rules.
+- Create `WORKFLOW.md` and `AGENTS.md` to document workflow rules.
 - Seed `/docs/` with placeholders for RFCs, ADRs, QA, Security, and Glossary.
 - Configure GitHub Actions for lint, test, coverage, and doc parity checks.
 - Introduce the PM role via `/roles/pm.hire.md`.


### PR DESCRIPTION
## Summary
- rename README.md to WORKFLOW.md
- add new top-level README describing how to use this repo as a template
- update doc parity references to use WORKFLOW.md

## Testing
- `echo "Running tests (none present)" && true`

------
https://chatgpt.com/codex/tasks/task_e_6883701865d48320ab5f3eb49059bc7e