### PR TITLE
Add .gitignore with common OS and language ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon?
+._*
+.Spotlight-V100
+.Trashes
+
+# Linux
+*~
+.*.swp
+.*.swo
+
+# Node
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+dist/
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.pyc
+.Python
+env/
+venv/
+build/
+.eggs/
+*.egg-info/
+


### PR DESCRIPTION
## Summary
- add a comprehensive `.gitignore` covering macOS, Linux, Node, and Python

## Testing
- `pytest -q`
- `npm test` *(fails: could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68837558870883209b0a943daa4e379d