### PR TITLE
Add example plan README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ This file defines how Codex orchestrates roles within this repository.
 ## Communication Between Agents
 - Role assignments and task outlines are committed to `plans/YYYY-MM-DD_<role>.agent.md`.
 - Each of these plan files is a simple text task that can be pasted directly into the Codex interface. Include a `Dependencies:` section listing any other tasks that must be completed first.
+- See `plans/README.example.agent.md` for a sample plan illustrating the expected format.
 - Agents exchange progress updates or questions in `messages/YYYY-MM-DD_<from>_to_<to>.md`.
 - Responses may be appended to the same file or placed in a new dated file.
 - The Orchestrator reviews these message files to decide on further role switches.

--- a/plans/README.example.agent.md
+++ b/plans/README.example.agent.md
@@ -1,0 +1,13 @@
+# Plan File Example
+
+Plan files outline single tasks for agents. Each file name should follow `YYYY-MM-DD_<role>.agent.md`.
+Keep the description short so it can be pasted into the Codex web interface.
+
+Example contents:
+
+```
+Implement login endpoint for the API.
+
+Dependencies:
+- 2025-07-24_backend_setup.agent.md
+```


### PR DESCRIPTION
## Summary
- add a plan file example with a `Dependencies:` section
- link to that example from **AGENTS.md** so new contributors can see the expected format

## Testing
- `echo "No programmatic checks defined" && true`

------
https://chatgpt.com/codex/tasks/task_e_68837571df308320af45313ab3338e36