### PR TITLE
Add doc parity script and update CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Coverage
         run: echo "Check coverage >= 90% lines and 80% branches"
       - name: Doc Parity
-        run: echo "Ensure WORKFLOW and AGENTS are updated"
+        run: ./scripts/doc_parity_check.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ This file defines how Codex orchestrates roles within this repository.
 4. Remove finished plan files and summarize the outcome in `docs/FEATURES.md`.
 5. Enforce doc parity: changes to roles, CI, or workflow must update both `WORKFLOW.md` and this file.
 6. Maintain CI configuration in `.github/workflows/ci.yml`.
+7. The CI pipeline runs `scripts/doc_parity_check.sh` to verify doc parity.
 
 ## Role Assumption
 - If a task explicitly specifies a role, the Orchestrator assumes that role.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -23,6 +23,7 @@ Each plan file contains a concise task description that can be pasted directly i
 ## Continuous Integration
 - CI uses GitHub Actions (`.github/workflows/ci.yml`).
 - Specific lint, test, and coverage steps are defined by project requirements gathered by the PM role.
+- A doc parity check runs `scripts/doc_parity_check.sh` to ensure updates to roles or CI also modify both docs.
 
 ## Getting Started
 1. Review `AGENTS.md` to understand how roles are assumed.

--- a/scripts/doc_parity_check.sh
+++ b/scripts/doc_parity_check.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine the base branch to diff against. Default to origin/main.
+BASE_BRANCH="${BASE_BRANCH:-origin/main}"
+
+# Attempt to fetch the base branch. Fallback to the previous commit if unavailable.
+if git show-ref --quiet "$BASE_BRANCH" || git fetch origin main "$BASE_BRANCH" >/dev/null 2>&1; then
+    BASE_REF="$BASE_BRANCH"
+elif git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+    BASE_REF="HEAD~1"
+else
+    BASE_REF="HEAD"
+fi
+
+# List files changed compared to the chosen base reference
+CHANGED_FILES=$(git diff --name-only "$BASE_REF"...HEAD)
+
+# Flags for docs
+AGENTS_CHANGED=false
+WORKFLOW_CHANGED=false
+
+if echo "$CHANGED_FILES" | grep -Fxq "AGENTS.md"; then
+    AGENTS_CHANGED=true
+fi
+if echo "$CHANGED_FILES" | grep -Fxq "WORKFLOW.md"; then
+    WORKFLOW_CHANGED=true
+fi
+
+# If roles or workflow definitions changed, ensure both docs changed
+if echo "$CHANGED_FILES" | grep -qE '^(roles/|\.github/workflows/)'; then
+    if [ "$AGENTS_CHANGED" != true ] || [ "$WORKFLOW_CHANGED" != true ]; then
+        echo "Doc parity check failed: Changes to roles or CI workflows require updates to AGENTS.md and WORKFLOW.md." >&2
+        exit 1
+    fi
+fi
+
+echo "Doc parity check passed." 


### PR DESCRIPTION
## Summary
- add `scripts/doc_parity_check.sh` for verifying workflow/role doc parity
- run the script from the Doc Parity step in `ci.yml`
- document the new script under the CI section of `WORKFLOW.md`
- note doc parity script usage in `AGENTS.md`

## Testing
- `./scripts/doc_parity_check.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883758162a0832082fb9779150ef5c4