### PR TITLE
Add example plan and messaging docs

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -10,7 +10,7 @@ This repository defines a multi-agent workflow orchestrated by Codex. The Orches
 Each role keeps its own `roles/<role>.work.md` file updated with insights during execution. Only the Orchestrator may edit other roles’ files or workflow documents, and roles must request such changes via a message file.
 
 ## Agent Communication
-Task assignments are committed to the `plans/` directory. Agents exchange progress or questions in `messages/YYYY-MM-DD_<from>_to_<to>.md`. These files provide a persistent record so the Orchestrator can seamlessly switch roles with minimal user involvement.
+Task assignments are committed to the `plans/` directory. Agents exchange progress or questions in `messages/YYYY-MM-DD_<from>_to_<to>.md`. These files provide a persistent record so the Orchestrator can seamlessly switch roles with minimal user involvement. See `plans/EXAMPLE_YYYY-MM-DD_pm.agent.md` and `messages/EXAMPLE_YYYY-MM-DD_pm_to_orchestrator.md` for reference formats.
 
 ## Task Requests and Dependencies
 Each plan file contains a concise task description that can be pasted directly into the Codex web interface. Prefer small, single-responsibility tasks that one role can complete. When a task requires other tasks to finish first, add a `Dependencies:` section listing those prerequisites.

--- a/messages/EXAMPLE_YYYY-MM-DD_pm_to_orchestrator.md
+++ b/messages/EXAMPLE_YYYY-MM-DD_pm_to_orchestrator.md
@@ -1,0 +1,1 @@
+The PM has completed the initial planning. Please delegate the next task to the backend role.

--- a/plans/EXAMPLE_YYYY-MM-DD_pm.agent.md
+++ b/plans/EXAMPLE_YYYY-MM-DD_pm.agent.md
@@ -1,0 +1,4 @@
+Implement the initial project setup and documentation.
+
+Dependencies:
+- EXAMPLE_YYYY-MM-DD_orchestrator.agent.md


### PR DESCRIPTION
## Summary
- add sample plan file with Dependencies block
- add sample message file
- cross-reference the examples in WORKFLOW documentation

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68837586a480832091441a36e0fdf722