### PR TITLE
Fix role files and clarify docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,9 @@ This file defines how Codex orchestrates roles within this repository.
 - The PM role may further delegate to specialist roles (frontend, backend, QA, UX, etc.).
 
 ## Role Files and Insights
-- Each role maintains a file under `roles/hired/<role>.md` to capture insights and lessons learned during execution.
+- New role proposals live under `roles/request/` until the Orchestrator approves them.
+- Approved roles are moved to `roles/hired/<role>.md` and each file stores the role preprompt.
+- Agents append additional insights to their own file as they gain experience.
 - Agents may only edit their own `roles/hired/<role>.md` file. Edits to other roles' files or workflow documentation must be requested via a message to the Orchestrator.
 - Role switching into the Orchestrator is disallowed. Only tasks that explicitly request the Orchestrator can start it.
 - The Orchestrator does not switch to project‑specific roles but can read any file. Its modifications are limited to workflow files and documentation.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -7,7 +7,7 @@ This repository defines a multi-agent workflow orchestrated by Codex. The Orches
 - New tasks are placed in `work/planned/YYYY-MM-DD_<role>.agent.md`.
 - See `AGENTS.md` for detailed rules.
 
-Each role keeps its own `roles/hired/<role>.md` file updated with insights during execution. Only the Orchestrator may edit other roles’ files or workflow documents, and roles must request such changes via a message file.
+Each role sources its `roles/hired/<role>.md` file at the start of work. This file begins as a preprompt written by the Orchestrator and grows as the role appends new insights. Role proposals remain in `roles/request/` until the Orchestrator hires them. Only the Orchestrator may edit other roles’ files or workflow documents, and roles must request such changes via a message file.
 
 ## Agent Communication
 Task assignments are committed to `work/planned/`. Agents exchange progress or questions in `messages/YYYY-MM-DD_<from>_to_<to>.md`. These files provide a persistent record so the Orchestrator can seamlessly switch roles with minimal user involvement. See `work/planned/EXAMPLE_YYYY-MM-DD_pm.agent.md` and `messages/EXAMPLE_YYYY-MM-DD_pm_to_orchestrator.md` for reference formats.

--- a/roles/hired/orchestrator.md
+++ b/roles/hired/orchestrator.md
@@ -1,3 +1,8 @@
-# Orchestrator Work Log
+# Orchestrator Role Preprompt
 
-Notes for orchestrator-specific workflow updates and governance decisions.
+Begin each session with these principles:
+- Evaluate tasks and assign the appropriate role.
+- Maintain doc parity by updating both `WORKFLOW.md` and `AGENTS.md` when roles or CI change.
+- Use the filesystem for inter-agent communication and task tracking.
+
+Add new orchestrator insights below as they are discovered.

--- a/roles/hired/pm.md
+++ b/roles/hired/pm.md
@@ -1,3 +1,9 @@
-# PM Work Log
+# PM Role Preprompt
 
-Use this file to track project-management insights and decisions.
+Start each session by reviewing these guidelines:
+- Gather initial requirements from the client.
+- Decide on the technology stack and update CI commands accordingly.
+- Maintain the backlog and delegate tasks to specialist roles as needed.
+- Ensure documentation in `/docs/` remains up to date.
+
+Append further insights below as they are learned.

--- a/roles/request/pm.md
+++ b/roles/request/pm.md
@@ -1,9 +1,0 @@
-# Project Manager Role
-
-Welcome to the project! As the PM, your responsibilities include:
-1. Gather initial requirements from the client.
-2. Decide on the technology stack and update CI commands accordingly.
-3. Maintain the backlog and delegate tasks to specialist roles as needed.
-4. Ensure documentation in `/docs/` remains up to date.
-
-Refer to `AGENTS.md` for orchestration rules.


### PR DESCRIPTION
## Summary
- remove outdated `roles/request/pm.md`
- convert PM and orchestrator files to role preprompts
- document how roles move from request to hired and how preprompts work

## Testing
- `./scripts/doc_parity_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68838df1721483208ddf86197550734d