### PR TITLE
Update role onboarding workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,9 +18,14 @@ This file defines how Codex orchestrates roles within this repository.
 - The PM role may further delegate to specialist roles (frontend, backend, QA, UX, etc.).
 
 ## Role Files and Insights
-- New role proposals live under `roles/request/` until the Orchestrator approves them.
-- Approved roles are moved to `roles/hired/<role>.md` and each file stores the role preprompt.
-- Agents append additional insights to their own file as they gain experience.
+- When the Orchestrator defines a new role it creates `roles/request/<role>.md`.
+  This file contains the initial preprompt written by the Orchestrator.
+- The first time a new role runs it performs an onboarding pass: it reviews the
+  entire project in light of the preprompt, refines the description with any
+  insights it gains, appends those as the first "memories," and then moves its
+  file to `roles/hired/<role>.md`.
+- Subsequent sessions append additional insights to their own file as they gain
+  experience.
 - Agents may only edit their own `roles/hired/<role>.md` file. Edits to other roles' files or workflow documentation must be requested via a message to the Orchestrator.
 - Role switching into the Orchestrator is disallowed. Only tasks that explicitly request the Orchestrator can start it.
 - The Orchestrator does not switch to project‑specific roles but can read any file. Its modifications are limited to workflow files and documentation.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -7,7 +7,7 @@ This repository defines a multi-agent workflow orchestrated by Codex. The Orches
 - New tasks are placed in `work/planned/YYYY-MM-DD_<role>.agent.md`.
 - See `AGENTS.md` for detailed rules.
 
-Each role sources its `roles/hired/<role>.md` file at the start of work. This file begins as a preprompt written by the Orchestrator and grows as the role appends new insights. Role proposals remain in `roles/request/` until the Orchestrator hires them. Only the Orchestrator may edit other roles’ files or workflow documents, and roles must request such changes via a message file.
+Each role sources its role file at the start of work. When the Orchestrator defines a new role it writes the initial preprompt to `roles/request/<role>.md`. The first time that role runs, it completes an onboarding review of the entire project, refines its description with any insights, appends those notes as initial memories, and then moves the file to `roles/hired/<role>.md`. Only the Orchestrator may edit other roles’ files or workflow documents, and roles must request such changes via a message file.
 
 ## Agent Communication
 Task assignments are committed to `work/planned/`. Agents leave messages for one another in `messages/inbox/YYYY-MM-DD_<from>_to_<to>.md`. After responding, the recipient moves the file to `messages/read/`. Each reply should note which previous message it addresses. These files provide a persistent record so the Orchestrator can seamlessly switch roles with minimal user involvement. See `work/planned/EXAMPLE_YYYY-MM-DD_pm.agent.md` and `messages/inbox/EXAMPLE_YYYY-MM-DD_pm_to_orchestrator.md` for reference formats.


### PR DESCRIPTION
## Summary
- clarify role lifecycle between `requested/` and `hired/`
- note new onboarding review for roles before they move to `hired`

## Testing
- `scripts/doc_parity_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_68838f83861c83208bce21ed7da46242