### PR TITLE
Refine docs and examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,59 +1,40 @@
 # AGENTS Governance
 
-This file defines how Codex orchestrates roles within this repository.
+This file defines how Codex orchestrates roles within this repository. For the step-by-step task flow, see `WORKFLOW.md`.
 
 ## Orchestrator Responsibilities
-1. Examine each task and determine which role should handle it.
-2. Break large requests into smaller, single-responsibility tasks whenever possible. Each task file should note any other tasks it depends on.
-3. Log each new task under `work/planned/YYYY-MM-DD_<role>.agent.md`.
-4. Move a task to `work/in_progress/` when a role begins work. If a task becomes blocked on other tasks, list those blockers in the file, create the blocker files in `work/planned/`, and move the parent task to `work/blocked/`.
-5. When a task is complete, move its file to `work/completed/` and summarize the outcome in `docs/FEATURES.md`.
-6. Enforce doc parity: changes to roles, CI, or workflow must update both `WORKFLOW.md` and this file.
-7. Maintain CI configuration in `.github/workflows/ci.yml`.
-8. The CI pipeline runs `scripts/doc_parity_check.sh` to verify doc parity.
+- Evaluate each task and assign the most appropriate role, splitting large requests into smaller tasks when needed.
+- Log new tasks under `work/planned/YYYY-MM-DD_<role>.agent.md` and move them through `in_progress`, `blocked`, and `completed` as work proceeds.
+- Summarize completed tasks in `docs/FEATURES.md`.
+- Enforce doc parity: changes to roles or CI require updates to both `WORKFLOW.md` and this file.
+- Maintain CI configuration in `.github/workflows/ci.yml` and run `scripts/doc_parity_check.sh`.
 
 ## Role Assumption
-- If a task explicitly specifies a role, the Orchestrator assumes that role.
-- Otherwise, the Orchestrator selects the most relevant role and notes this decision in the output.
-- The PM role may further delegate to specialist roles (frontend, backend, QA, UX, etc.).
+- If a task names a role, the Orchestrator assumes it; otherwise it selects the best fit.
+- The PM may delegate to specialist roles as needed.
 
 ## Role Files and Insights
-- When the Orchestrator defines a new role it creates `roles/request/<role>.md`.
-  This file contains the initial preprompt written by the Orchestrator.
-- The first time a new role runs it performs an onboarding pass: it reviews the
-  entire project in light of the preprompt, refines the description with any
-  insights it gains, appends those as the first "memories," and then moves its
-  file to `roles/hired/<role>.md`.
-- Subsequent sessions append additional insights to their own file as they gain
-  experience.
-- Agents may only edit their own `roles/hired/<role>.md` file. Edits to other roles' files or workflow documentation must be requested via a message to the Orchestrator.
-- Role switching into the Orchestrator is disallowed. Only tasks that explicitly request the Orchestrator can start it.
-- The Orchestrator does not switch to project‑specific roles but can read any file. Its modifications are limited to workflow files and documentation.
+- When a new role is defined, the Orchestrator writes `roles/request/<role>.md` with its preprompt.
+- After onboarding the role moves to `roles/hired/<role>.md` and appends insights over time.
+- Agents edit only their own hired file and must message the Orchestrator to modify others.
+- Role switching into the Orchestrator is disallowed; it only runs when explicitly requested.
+- The Orchestrator may read any file but only edits workflow docs and governance files.
 
 ## Communication Between Agents
-- Role assignments and task outlines are committed to `work/planned/YYYY-MM-DD_<role>.agent.md`.
-- Each of these task files is a short description that can be pasted directly into the Codex interface. Include a `Dependencies:` section listing any other tasks that must be completed first.
-- See `work/planned/README.example.agent.md` for a sample file illustrating the expected format.
-- Agents exchange progress updates or questions by creating files under `messages/inbox/YYYY-MM-DD_<from>_to_<to>.md`.
-- After a role responds or acts, it moves the message to `messages/read/`.
-- Follow-up messages should mention which earlier message they address.
-- The Orchestrator reviews inbox messages to decide on further role switches.
-- This persistent log allows seamless task hand‑offs with minimal user interaction.
-- When a role starts a task it moves the file from `work/planned/` to `work/in_progress/`.
-- If a task requires help from other roles, note those blockers inside the file, create the necessary tasks in `work/planned/`, and move the blocked task to `work/blocked/`.
-- Roles should mark blockers resolved when completing their tasks. If the last blocker for a task is cleared, move that task back to `work/planned/`.
+- Task outlines live in `work/planned/` and may list `Dependencies:`.
+- Agents communicate via files in `messages/inbox/`, moving them to `messages/read/` after handling.
+- Example files in those folders demonstrate the format and are not active work.
 
 ## Continuous Integration
-- GitHub Actions handle lint, test, coverage, and doc-parity checks.
-- Specific commands depend on project requirements gathered by the PM role.
+- GitHub Actions handle lint, test, coverage, and doc-parity checks based on PM requirements.
 - Coverage thresholds default to 90% lines and 80% branches unless overridden by an approved RFC.
 
 ## Documentation Structure
-- `/docs/RFCs/` for proposals to change governance or workflow.
-- `/docs/ADRs/` for decisions about workflow policies.
-- `/docs/QA/` for bug reports and test strategies.
-- `/docs/SECURITY/` for threat models and mitigations.
-- `GLOSSARY.md` for terminology.
-- `/docs/FEATURES.md` for a running list of completed work.
+- `/docs/RFCs/` - proposals to change governance or workflow
+- `/docs/ADRs/` - decisions about workflow policies
+- `/docs/QA/` - bug reports and test strategies
+- `/docs/SECURITY/` - threat models and mitigations
+- `GLOSSARY.md` - terminology
+- `/docs/FEATURES.md` - running list of completed work
 
 This AGENTS.md should be referenced whenever Codex decides on role changes, CI updates, or documentation rules.

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This repository serves as a starting point for new multi-agent projects. It cont
 3. **Replace project-specific sections.** Update `README.md` in your project to describe your own code and goals while keeping `WORKFLOW.md` for the shared process.
 4. **Customize roles and CI as needed.** Add or modify role files under `roles/` and update CI steps once your tooling is defined.
 
-Refer to `WORKFLOW.md` for details on how agents communicate and how tasks are orchestrated.
+Refer to `WORKFLOW.md` for details on how agents communicate and how tasks are orchestrated. Example task and message files in `work/planned/` and `messages/inbox/` demonstrate the expected format. They are placeholders and do not represent active work.
 
 ## Version
 
-The current release is **0.0.1** as recorded in `VERSION.txt`. See `CHANGELOG.md` for details.
+The current release is **0.0.2** as recorded in `VERSION.txt`. See `CHANGELOG.md` for details.

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -1,16 +1,16 @@
 # Codex Project Workflow
 
-This repository defines a multi-agent workflow orchestrated by Codex. The Orchestrator Agent dynamically assumes roles (Project Manager, Frontend, Backend, QA, etc.) to fulfill tasks.
+This repository defines a multi-agent workflow orchestrated by Codex. The Orchestrator dynamically assumes roles (Project Manager, Frontend, Backend, QA, etc.) to fulfill tasks.
 
 ## Role Switching
 - The Orchestrator reviews each task and decides which role best fits.
 - New tasks are placed in `work/planned/YYYY-MM-DD_<role>.agent.md`.
 - See `AGENTS.md` for detailed rules.
 
-Each role sources its role file at the start of work. When the Orchestrator defines a new role it writes the initial preprompt to `roles/request/<role>.md`. The first time that role runs, it completes an onboarding review of the entire project, refines its description with any insights, appends those notes as initial memories, and then moves the file to `roles/hired/<role>.md`. Only the Orchestrator may edit other roles’ files or workflow documents, and roles must request such changes via a message file.
+Each role sources its role file at the start of work. New roles begin in `roles/request/` and, after onboarding, move to `roles/hired/` with any insights appended. Only the Orchestrator may edit other roles’ files or workflow documents; roles must request such changes via a message file.
 
 ## Agent Communication
-Task assignments are committed to `work/planned/`. Agents leave messages for one another in `messages/inbox/YYYY-MM-DD_<from>_to_<to>.md`. After responding, the recipient moves the file to `messages/read/`. Each reply should note which previous message it addresses. These files provide a persistent record so the Orchestrator can seamlessly switch roles with minimal user involvement. See `work/planned/EXAMPLE_YYYY-MM-DD_pm.agent.md` and `messages/inbox/EXAMPLE_YYYY-MM-DD_pm_to_orchestrator.md` for reference formats.
+Task assignments are committed to `work/planned/`. Agents leave messages for one another in `messages/inbox/YYYY-MM-DD_<from>_to_<to>.md` and move them to `messages/read/` after responding. Each reply notes which previous message it addresses. See the example files in those folders for the exact format; they are placeholders only.
 
 ## Task Requests and Dependencies
 Each task file contains a concise description that can be pasted directly into the Codex web interface. Prefer small, single-responsibility tasks that one role can complete. When a task requires other tasks to finish first, add a `Dependencies:` section listing those prerequisites.

--- a/docs/QA/BUG_REPORT.md
+++ b/docs/QA/BUG_REPORT.md
@@ -1,3 +1,14 @@
 # Bug Report Template
 
 Describe the bug, steps to reproduce, expected behavior, and environment. Attach logs or screenshots if helpful.
+
+## Example
+
+```text
+Bug: Placeholder example bug
+Steps to reproduce:
+1. Open the demo page
+2. Click the sample button
+Expected: Example output should appear
+Environment: Example OS 1.0
+```

--- a/docs/QA/TEST_STRATEGY.md
+++ b/docs/QA/TEST_STRATEGY.md
@@ -1,3 +1,7 @@
 # Test Strategy
 
 Testing requirements will be defined once the project stack is chosen. Default goal is 90% line coverage and 80% branch coverage.
+
+## Example
+
+If using Python, run `pytest --cov` and ensure the reported coverage meets the thresholds above.

--- a/docs/SECURITY/THREATS.md
+++ b/docs/SECURITY/THREATS.md
@@ -1,3 +1,8 @@
 # Security Threat Model
 
 Potential threats and mitigation strategies will be documented as the project evolves.
+
+## Example
+
+Potential threat: accidental exposure of demo credentials.
+Mitigation: store all example keys in a nonfunctional format and document that they are placeholders only.

--- a/messages/inbox/EXAMPLE_YYYY-MM-DD_pm_to_orchestrator.md
+++ b/messages/inbox/EXAMPLE_YYYY-MM-DD_pm_to_orchestrator.md
@@ -1,1 +1,5 @@
+# Example Message
+
+This placeholder demonstrates how PMs can request help from the Orchestrator. It is not an active task.
+
 The PM has completed the initial planning. Please delegate the next task to the backend role.

--- a/work/planned/EXAMPLE_YYYY-MM-DD_pm.agent.md
+++ b/work/planned/EXAMPLE_YYYY-MM-DD_pm.agent.md
@@ -1,4 +1,8 @@
+# Example Task
+
 Implement the initial project setup and documentation.
+
+This file is only an example and should not be processed as an active task.
 
 Dependencies:
 - EXAMPLE_YYYY-MM-DD_orchestrator.agent.md

--- a/work/planned/README.example.agent.md
+++ b/work/planned/README.example.agent.md
@@ -1,5 +1,7 @@
 # Task File Example
 
+This file illustrates the expected format for planned tasks. It is not an actual request.
+
 Task files outline single pieces of work for agents. Each file name should follow `YYYY-MM-DD_<role>.agent.md`.
 Keep the description short so it can be pasted into the Codex web interface.
 


### PR DESCRIPTION
## Summary
- clarify doc structure in `AGENTS.md` and cross-reference `WORKFLOW.md`
- streamline workflow notes and highlight placeholders
- update README with version fix and note example files
- mark example messages and task files clearly
- add example sections to QA and security docs

## Testing
- `scripts/doc_parity_check.sh`


------
https://chatgpt.com/codex/tasks/task_e_688391821ab4832088482c4a7d6b768a